### PR TITLE
Generate and download scrutiny report pdf

### DIFF
--- a/app/(protected)/admindashboard/generate/bulk-scrutee-sheet/page.tsx
+++ b/app/(protected)/admindashboard/generate/bulk-scrutee-sheet/page.tsx
@@ -177,7 +177,9 @@ export default function BulkScrutinySheetPage() {
         field31: workdetails.finalEstimateAmount.toFixed(2),
         agencytable: workdetails.biddingAgencies.map((agency, index) => [
           (index + 1).toString(),
-          agency.agencydetails.name,
+          agency?.agencydetails?.agencyType === "FARM" && agency?.agencydetails?.proprietorName
+            ? `${agency.agencydetails.name} (${agency.agencydetails.proprietorName})`
+            : agency.agencydetails.name,
           workdetails.participationFee.toFixed(2),
           workdetails.earnestMoneyFee.toFixed(2),
           agency.technicalEvelution?.credencial?.sixtyperamtput ? "Yes" : "No",

--- a/app/(protected)/admindashboard/generate/page.tsx.txt
+++ b/app/(protected)/admindashboard/generate/page.tsx.txt
@@ -168,7 +168,9 @@ export default function BulkScrutinySheetPage() {
         field31: workdetails.finalEstimateAmount.toFixed(2),
         agencytable: workdetails.biddingAgencies.map((agency, index) => [
           (index + 1).toString(),
-          agency.agencydetails.name,
+          agency?.agencydetails?.agencyType === "FARM" && agency?.agencydetails?.proprietorName
+            ? `${agency.agencydetails.name} (${agency.agencydetails.proprietorName})`
+            : agency.agencydetails.name,
           workdetails.participationFee.toFixed(2),
           workdetails.earnestMoneyFee.toFixed(2),
           agency.technicalEvelution?.credencial?.sixtyperamtput ? "Yes" : "No",

--- a/components/PrintTemplet/ScrutnisheetTemplete.tsx
+++ b/components/PrintTemplet/ScrutnisheetTemplete.tsx
@@ -64,7 +64,9 @@ export default function PDFGeneratorComponent({
           field31: workdetails.finalEstimateAmount.toFixed(2),
           agencytable: workdetails.biddingAgencies.map((agency, index) => [
             (index + 1).toString(),
-            agency.agencydetails.name,
+            agency?.agencydetails?.agencyType === "FARM" && agency?.agencydetails?.proprietorName
+              ? `${agency.agencydetails.name} (${agency.agencydetails.proprietorName})`
+              : agency.agencydetails.name,
             workdetails.participationFee.toFixed(2),
             workdetails.earnestMoneyFee.toFixed(2),
             agency.technicalEvelution?.credencial?.sixtyperamtput


### PR DESCRIPTION
Display proprietor name in brackets for 'FARM' type agencies in scrutiny sheets.

---
<a href="https://cursor.com/background-agent?bcId=bc-23ad84a9-2ed1-4876-88a7-2d762accf3fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-23ad84a9-2ed1-4876-88a7-2d762accf3fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

