### PR TITLE
Format farm agency name in brackets

### DIFF
--- a/components/PrintTemplet/Agrement-certificate.tsx
+++ b/components/PrintTemplet/Agrement-certificate.tsx
@@ -14,6 +14,13 @@ export const AgrementCertificate = ({ agrement }: { agrement: Agreement }) => {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
 
+  const formatAgencyDisplayName = (agency: any): string => {
+    const baseName = agency?.name || "";
+    const isFarm = agency?.agencyType === "FARM";
+    const proprietor = agency?.proprietorName || "";
+    return isFarm && proprietor ? `${baseName} (${proprietor})` : baseName;
+  };
+
   const handleGeneratePDF = async () => {
     setIsGenerating(true);
     setError(null);
@@ -24,7 +31,7 @@ export const AgrementCertificate = ({ agrement }: { agrement: Agreement }) => {
     const details = `This Contract made on ${formatDate(
       agrement.aggrementdate
     )}, between the Pradhan,No 4 Harsura Gram Panchayat  , Vill-Suhari, PO-Rampur, PS-Tapan, Dist.-D/Dinajpur. of West Bengal,  hereinafter “The First Party” of the one part and  ${
-      agrement.acceptagency.agencydetails.name
+      formatAgencyDisplayName(agrement.acceptagency.agencydetails)
     }, ${
       agrement.acceptagency.agencydetails.contactDetails
     } hereinafter “The Second Party” or the “Contractor” of the other part:`;

--- a/components/PrintTemplet/CoverPage.tsx
+++ b/components/PrintTemplet/CoverPage.tsx
@@ -20,6 +20,13 @@ export default function CoverPagePrint({
 }: CoverPagePDFProps) {
   const [isGenerating, setIsGenerating] = useState(false);
 
+  const formatAgencyDisplayName = (agency: any): string => {
+    const baseName = agency?.name || "";
+    const isFarm = agency?.agencyType === "FARM";
+    const proprietor = agency?.proprietorName || "";
+    return isFarm && proprietor ? `${baseName} (${proprietor})` : baseName;
+  };
+
   const fyear = workCoverPageType.completionDate
     ? getFinancialYear(workCoverPageType.completionDate)
     : "N/A";
@@ -62,7 +69,7 @@ export default function CoverPagePrint({
                 )
               : ""
           }`,
-          agencydetails: `${workCoverPageType.AwardofContract?.workorderdetails[0].Bidagency?.agencydetails.name} Address: ${workCoverPageType.AwardofContract?.workorderdetails[0].Bidagency?.agencydetails.contactDetails} Mobile No ${workCoverPageType.AwardofContract?.workorderdetails[0].Bidagency?.agencydetails.mobileNumber}`,
+          agencydetails: `${formatAgencyDisplayName(workCoverPageType.AwardofContract?.workorderdetails[0].Bidagency?.agencydetails)} Address: ${workCoverPageType.AwardofContract?.workorderdetails[0].Bidagency?.agencydetails.contactDetails} Mobile No ${workCoverPageType.AwardofContract?.workorderdetails[0].Bidagency?.agencydetails.mobileNumber}`,
 
           // [[\"₹123,564.00\",\"₹123,564.00\",\"₹123,564.00\"]]"
           fundetailstable: [

--- a/components/PrintTemplet/ScrutnisheetTemplete.tsx
+++ b/components/PrintTemplet/ScrutnisheetTemplete.tsx
@@ -16,6 +16,13 @@ const toTitleCase = (str: string) => {
     return word.charAt(0).toUpperCase() + word.substring(1).toLowerCase();
   });
 };
+
+const formatAgencyDisplayName = (agency: any): string => {
+  const baseName = agency?.name || "";
+  const isFarm = agency?.agencyType === "FARM";
+  const proprietor = agency?.proprietorName || "";
+  return isFarm && proprietor ? `${baseName} (${proprietor})` : baseName;
+};
 type PDFGeneratorProps = {
   workdetails: workdetailsforprint;
 };
@@ -64,7 +71,7 @@ export default function PDFGeneratorComponent({
           field31: workdetails.finalEstimateAmount.toFixed(2),
           agencytable: workdetails.biddingAgencies.map((agency, index) => [
             (index + 1).toString(),
-            agency.agencydetails.name,
+            formatAgencyDisplayName(agency.agencydetails),
             workdetails.participationFee.toFixed(2),
             workdetails.earnestMoneyFee.toFixed(2),
             agency.technicalEvelution?.credencial?.sixtyperamtput

--- a/components/PrintTemplet/Supply-order.tsx
+++ b/components/PrintTemplet/Supply-order.tsx
@@ -32,6 +32,13 @@ export default function SupplyOrder({
 }: WorkOrderCertificatePDFProps) {
   const [isGenerating, setIsGenerating] = useState(false);
 
+  const formatAgencyDisplayName = (agency: any): string => {
+    const baseName = agency?.name || "";
+    const isFarm = agency?.agencyType === "FARM";
+    const proprietor = agency?.proprietorName || "";
+    return isFarm && proprietor ? `${baseName} (${proprietor})` : baseName;
+  };
+
   const getNitYear = (): number => {
     const memoDate =
       workOrderDetails.Bidagency?.WorksDetail?.nitDetails?.memoDate;
@@ -95,7 +102,7 @@ export default function SupplyOrder({
             formatDate(
               workOrderDetails.awardofcontractdetails?.workordeermemodate
             ) || "",
-          agencyname: workOrderDetails.Bidagency?.agencydetails?.name || "",
+          agencyname: formatAgencyDisplayName(workOrderDetails.Bidagency?.agencydetails),
           agencyadd: `${
             workOrderDetails.Bidagency?.agencydetails?.contactDetails || ""
           } - ${workOrderDetails.Bidagency?.agencydetails.mobileNumber || ""}`,

--- a/components/PrintTemplet/Work-order-Certificate.tsx
+++ b/components/PrintTemplet/Work-order-Certificate.tsx
@@ -33,6 +33,13 @@ const toTitleCase = (str: string) => {
   });
 };
 
+const formatAgencyDisplayName = (agency: any): string => {
+  const baseName = agency?.name || "";
+  const isFarm = agency?.agencyType === "FARM";
+  const proprietor = agency?.proprietorName || "";
+  return isFarm && proprietor ? `${baseName} (${proprietor})` : baseName;
+};
+
 export default function Component({
   workOrderDetails,
 }: WorkOrderCertificatePDFProps) {
@@ -105,7 +112,7 @@ export default function Component({
           gpname2: `${nameinprodhan}`,
           gpname3: `${nameinprodhan}`,
           refdate: formattedWorkOrderDate,
-          agencyname: workOrderDetails.Bidagency?.agencydetails?.name || "",
+          agencyname: formatAgencyDisplayName(workOrderDetails.Bidagency?.agencydetails),
           agencyadd: `${workOrderDetails.Bidagency?.agencydetails?.contactDetails || ""} - ${workOrderDetails.Bidagency?.agencydetails?.mobileNumber || ""}`,
           fund: workOrderDetails.Bidagency?.WorksDetail?.ApprovedActionPlanDetails?.schemeName || "",
           worksl: `${workOrderDetails.Bidagency?.WorksDetail?.workslno || ""} out of ${nitworkcount}`,

--- a/components/PrintTemplet/Work-order-Certificate.tsx
+++ b/components/PrintTemplet/Work-order-Certificate.tsx
@@ -33,13 +33,6 @@ const toTitleCase = (str: string) => {
   });
 };
 
-const formatAgencyDisplayName = (agency: any): string => {
-  const baseName = agency?.name || "";
-  const isFarm = agency?.agencyType === "FARM";
-  const proprietor = agency?.proprietorName || "";
-  return isFarm && proprietor ? `${baseName} (${proprietor})` : baseName;
-};
-
 export default function Component({
   workOrderDetails,
 }: WorkOrderCertificatePDFProps) {
@@ -112,7 +105,7 @@ export default function Component({
           gpname2: `${nameinprodhan}`,
           gpname3: `${nameinprodhan}`,
           refdate: formattedWorkOrderDate,
-          agencyname: formatAgencyDisplayName(workOrderDetails.Bidagency?.agencydetails),
+          agencyname: workOrderDetails.Bidagency?.agencydetails?.name || "",
           agencyadd: `${workOrderDetails.Bidagency?.agencydetails?.contactDetails || ""} - ${workOrderDetails.Bidagency?.agencydetails?.mobileNumber || ""}`,
           fund: workOrderDetails.Bidagency?.WorksDetail?.ApprovedActionPlanDetails?.schemeName || "",
           worksl: `${workOrderDetails.Bidagency?.WorksDetail?.workslno || ""} out of ${nitworkcount}`,

--- a/components/PrintTemplet/completation-certificate.tsx
+++ b/components/PrintTemplet/completation-certificate.tsx
@@ -17,6 +17,13 @@ export default function Completationcertificate({
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
 
+  const formatAgencyDisplayName = (agency: any): string => {
+    const baseName = agency?.name || "";
+    const isFarm = agency?.agencyType === "FARM";
+    const proprietor = agency?.proprietorName || "";
+    return isFarm && proprietor ? `${baseName} (${proprietor})` : baseName;
+  };
+
   const handleGeneratePDF = async () => {
     setIsGenerating(true);
     setError(null);
@@ -27,7 +34,7 @@ export default function Completationcertificate({
 
       const inputs = [
         {
-          agencydetails: `This is to certify that ${paymentdetails.AwardofContract?.workorderdetails?.[0]?.Bidagency?.agencydetails.name}, located at ${paymentdetails.AwardofContract?.workorderdetails?.[0]?.Bidagency?.agencydetails.contactDetails}, has successfully completed the following work:`,
+          agencydetails: `This is to certify that ${formatAgencyDisplayName(paymentdetails.AwardofContract?.workorderdetails?.[0]?.Bidagency?.agencydetails)}, located at ${paymentdetails.AwardofContract?.workorderdetails?.[0]?.Bidagency?.agencydetails.contactDetails}, has successfully completed the following work:`,
           workname:
             paymentdetails.ApprovedActionPlanDetails.activityDescription,
           nitdetails: `${

--- a/components/PrintTemplet/payment-certificate.tsx
+++ b/components/PrintTemplet/payment-certificate.tsx
@@ -18,6 +18,13 @@ export default function PaymentCertificate({
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
 
+  const formatAgencyDisplayName = (agency: any): string => {
+    const baseName = agency?.name || "";
+    const isFarm = agency?.agencyType === "FARM";
+    const proprietor = agency?.proprietorName || "";
+    return isFarm && proprietor ? `${baseName.toUpperCase()} (${proprietor.toUpperCase()})` : baseName.toUpperCase();
+  };
+
   const handleGeneratePDF = async () => {
     setIsGenerating(true);
     setError(null);
@@ -49,7 +56,7 @@ export default function PaymentCertificate({
       const inputs = [
         {
           agencydetails: `PAYMENT CERTIFICATE ISSUED TO ${
-            agencyDetails?.name?.toUpperCase() || "N/A"
+            agencyDetails ? formatAgencyDisplayName(agencyDetails) : "N/A"
           }, ${
             agencyDetails?.contactDetails?.toUpperCase() || "N/A"
           } BY THE PRADHAN OF NO 3 DHALPARA GRAM PANCHAYAT`,

--- a/types/agreement.ts
+++ b/types/agreement.ts
@@ -16,6 +16,8 @@ export type Agreement = {
     agencydetails: {
       name: string;
       contactDetails: string;
+      agencyType?: "FARM" | "INDIVIDUAL";
+      proprietorName?: string | null;
     };
   };
 };


### PR DESCRIPTION
Add proprietor name in brackets to agency display name in `completation-certificate.tsx` when agency type is 'FARM'.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fb8cf25-9fff-4102-acdb-c730ceffa431">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0fb8cf25-9fff-4102-acdb-c730ceffa431">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

